### PR TITLE
Increase support for large numbers.

### DIFF
--- a/timexy/language.py
+++ b/timexy/language.py
@@ -11,7 +11,6 @@ class Language(BaseModel):
     months: List[List[str]]
     units: Dict["str", List[str]]
     num_words: List[str]
-    modifiers: List[str]
     word_to_digit: Callable[[str], str]
     rules: List[Rule] = []
 

--- a/timexy/language.py
+++ b/timexy/language.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 
 from pydantic import BaseModel
 
@@ -11,6 +11,8 @@ class Language(BaseModel):
     months: List[List[str]]
     units: Dict["str", List[str]]
     num_words: List[str]
+    modifiers: List[str]
+    word_to_digit: Callable[[str], str]
     rules: List[Rule] = []
 
     def get_month_re(self) -> str:

--- a/timexy/languages/de.py
+++ b/timexy/languages/de.py
@@ -46,6 +46,8 @@ de = Language(
         ["November", "Nov"],
         ["Dezember", "Dez"],
     ],
+    modifiers=[],
+    word_to_digit=lambda n: de.num_words.index(n),
 )
 de.rules = [
     Rule(

--- a/timexy/languages/de.py
+++ b/timexy/languages/de.py
@@ -46,7 +46,6 @@ de = Language(
         ["November", "Nov"],
         ["Dezember", "Dez"],
     ],
-    modifiers=[],
     word_to_digit=lambda n: de.num_words.index(n),
 )
 de.rules = [

--- a/timexy/languages/en.py
+++ b/timexy/languages/en.py
@@ -28,7 +28,6 @@ en = Language(
         ["November", "Nov"],
         ["December", "Dec"],
     ],
-    modifiers=["and"],
     word_to_digit=lambda n: numerize(n),
 )
 

--- a/timexy/languages/en.py
+++ b/timexy/languages/en.py
@@ -1,3 +1,5 @@
+from numerizer import numerize
+
 from ..language import Language
 from ..rule import Rule
 
@@ -10,27 +12,7 @@ en = Language(
         "D": ["day", "days"],
     },
     num_words=[
-        "zero",
-        "one",
-        "two",
-        "three",
-        "four",
-        "five",
-        "six",
-        "seven",
-        "eight",
-        "nine",
-        "ten",
-        "eleven",
-        "twelve",
-        "thirteen",
-        "fourteen",
-        "fifteen",
-        "sixteen",
-        "seventeen",
-        "eighteen",
-        "nineteen",
-        "twenty",
+        # TODO: remove when word_to_digit is implemented for German & French
     ],
     months=[
         ["January", "Jan"],
@@ -46,6 +28,8 @@ en = Language(
         ["November", "Nov"],
         ["December", "Dec"],
     ],
+    modifiers=["and"],
+    word_to_digit=lambda n: numerize(n),
 )
 
 en.rules = [

--- a/timexy/languages/fr.py
+++ b/timexy/languages/fr.py
@@ -46,7 +46,6 @@ fr = Language(
         ["novembre", "nov"],
         ["décembre", "déc"],
     ],
-    modifiers=[],
     word_to_digit=lambda n: fr.num_words.index(n),
 )
 fr.rules = [

--- a/timexy/languages/fr.py
+++ b/timexy/languages/fr.py
@@ -46,6 +46,8 @@ fr = Language(
         ["novembre", "nov"],
         ["décembre", "déc"],
     ],
+    modifiers=[],
+    word_to_digit=lambda n: fr.num_words.index(n),
 )
 fr.rules = [
     Rule(

--- a/timexy/timexy.py
+++ b/timexy/timexy.py
@@ -82,16 +82,8 @@ class Timexy:
                     key,
                     [
                         [
-                            {"LIKE_NUM": True, "OP": "+"},
-                            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
-                            {"LIKE_NUM": True, "OP": "*"},
-                            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
-                            {"LIKE_NUM": True, "OP": "*"},
-                            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
-                            {"LIKE_NUM": True, "OP": "*"},
-                            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
-                            {"LIKE_NUM": True, "OP": "*"},
-                            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
+                            {"LIKE_NUM": True},
+                            {"OP": "+"},
                             {"LOWER": val.lower()},
                         ]
                     ],
@@ -113,6 +105,9 @@ class Timexy:
                 and not self.overwrite
             ):
                 continue
+
+            # TODO: prefer rule-based date matches before Matcher durations
+            # failing example: "Today is Feb 1990, six years after Feb 1984."
 
             # if overlapping entities due to multiple matched date patterns,
             # keep entity with longest span and dump others


### PR DESCRIPTION
Thanks for creating this @paulrinckens!

I am interested in extending this to Portuguese, but I faced a compatibility issue: the number 14 can be written as both "catorze" or "quatorze", however Timexy only allows for one orthography due to the way `num_words` is indexed.

I think this can be resolved while also extending Timexy's support for durations longer than 20: by leveraging the `LIKE_NUM` attribute in the Matcher class, we can let spaCy do the heavy lifting.

```py
self.matcher.add(
    key,
    [
        [
            {"LIKE_NUM": True, "OP": "+"},
            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
            {"LIKE_NUM": True, "OP": "*"},
            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
            {"LIKE_NUM": True, "OP": "*"},
            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
            {"LIKE_NUM": True, "OP": "*"},
            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
            {"LIKE_NUM": True, "OP": "*"},
            {"LOWER": {"IN": self.timexy_lang.modifiers}, "OP": "*"},
            {"LOWER": val.lower()},
        ]
    ],
    greedy="LONGEST"
)
```

In English, "and" may or may not appear in number words, but `LIKE_NUM` does not seem to capture this. I've therefore added optional modifiers (and optional subsequent number words) to allow for English numbers into the trillions.

We can also leverage the [`numerizer`](https://spacy.io/universe/project/numerizer) spaCy extension for converting number words into digits. Unfortunately it is only compatible with English at the moment, but it's great at what it does. Another candidate is [`text2num`](https://github.com/allo-media/text2num), which already supports multiple languages and seems to be under active development. Otherwise, it should also be feasible to implement a local method when adding new languages in lieu of using an external library, at least for numbers into the thousands or maybe millions. In any case, the changes made in this PR enhance support for English but don't break compatibility for German or French.